### PR TITLE
option to enable `case sensitive` headers

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -16,6 +16,7 @@ const USER_AGENT = 'artillery ' + VERSION + ' (https://artillery.io)';
 const engineUtil = require('./engine_util');
 const template = engineUtil.template;
 const fileReference = engineUtil.fileReference;
+const removeDuplicatedKeys = engineUtil.removeDuplicatedKeys;
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
@@ -191,12 +192,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     // Assign default headers then overwrite as needed
     let defaultHeaders = (config.defaults && config.defaults.headers) ?
         config.defaults.headers : {'user-agent': USER_AGENT};
-    if (!config.caseSensitiveHeaderKeys) {
-      defaultHeaders = lowcaseKeys(defaultHeaders);
-    }
-    requestParams.headers = _.extend(defaultHeaders,
-                                     (!config.caseSensitiveHeaderKeys) ? 
-                                      lowcaseKeys(params.headers) : params.header);
+
+    requestParams.headers = _.mergeWith({}, defaultHeaders,
+      (config.caseSensitiveHeaderKeys) ? params.header : lowcaseKeys(params.header),
+      removeDuplicatedKeys);
+
     let headers = _.reduce(requestParams.headers,
                           function(acc, v, k) {
                             acc[k] = template(v, context);

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -191,11 +191,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     // Assign default headers then overwrite as needed
     let defaultHeaders = (config.defaults && config.defaults.headers) ?
         config.defaults.headers : {'user-agent': USER_AGENT};
-    if (config.lowcaseHeaderKeys) {
+    if (!config.caseSensitiveHeaderKeys) {
       defaultHeaders = lowcaseKeys(defaultHeaders);
     }
     requestParams.headers = _.extend(defaultHeaders,
-                                     (config.lowcaseHeaderKeys) ? 
+                                     (!config.caseSensitiveHeaderKeys) ? 
                                       lowcaseKeys(params.headers) : params.header);
     let headers = _.reduce(requestParams.headers,
                           function(acc, v, k) {

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -189,11 +189,14 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     }
 
     // Assign default headers then overwrite as needed
-    let defaultHeaders = lowcaseKeys(
-      (config.defaults && config.defaults.headers) ?
-        config.defaults.headers : {'user-agent': USER_AGENT});
+    let defaultHeaders = (config.defaults && config.defaults.headers) ?
+        config.defaults.headers : {'user-agent': USER_AGENT};
+    if (config.lowcaseHeaderKeys) {
+      defaultHeaders = lowcaseKeys(defaultHeaders);
+    }
     requestParams.headers = _.extend(defaultHeaders,
-                                     lowcaseKeys(params.headers));
+                                     (config.lowcaseHeaderKeys) ? 
+                                      lowcaseKeys(params.headers) : params.header);
     let headers = _.reduce(requestParams.headers,
                           function(acc, v, k) {
                             acc[k] = template(v, context);

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -466,7 +466,7 @@ function fileReference(body, config) {
 
 function removeDuplicatedKeys(objValue, srcValue, key, object) {
   Object.keys(object)
-    .filter((existKey) => existKey.toLowerCase() === key.toLowerCase())
+    .filter((existKey) => existKey.toLowerCase() === key.toLowerCase() && existKey !== key)
     .forEach((duplicatedKey) => delete object[duplicatedKey]);
   return srcValue;
 }

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -465,8 +465,8 @@ function fileReference(body, config) {
 }
 
 function removeDuplicatedKeys(objValue, srcValue, key, object) {
-  Object.keys(object)
-    .filter((existKey) => existKey.toLowerCase() === key.toLowerCase() && existKey !== key)
-    .forEach((duplicatedKey) => delete object[duplicatedKey]);
+  _.keys(object)
+    .filter(function(existKey){ return existKey.toLowerCase() === key.toLowerCase() })
+    .forEach(function(duplicatedKey){ _.unset(object,duplicatedKey) });
   return srcValue;
 }

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -465,8 +465,8 @@ function fileReference(body, config) {
 }
 
 function removeDuplicatedKeys(objValue, srcValue, key, object) {
-  _.keys(object)
+  L.keys(object)
     .filter(function(existKey){ return existKey.toLowerCase() === key.toLowerCase() })
-    .forEach(function(duplicatedKey){ _.unset(object,duplicatedKey) });
+    .forEach(function(duplicatedKey){ L.unset(object,duplicatedKey) });
   return srcValue;
 }

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -30,7 +30,8 @@ module.exports = {
   template: template,
   captureOrMatch,
   evil: evil,
-  _renderVariables: renderVariables
+  _renderVariables: renderVariables,
+  removeDuplicatedKeys: removeDuplicatedKeys
 };
 
 function createThink(requestSpec, opts) {
@@ -461,4 +462,11 @@ function fileReference(body, config) {
   }
 
   return reference;
+}
+
+function removeDuplicatedKeys(objValue, srcValue, key, object) {
+  Object.keys(object)
+    .filter((existKey) => existKey.toLowerCase() === key.toLowerCase())
+    .forEach((duplicatedKey) => delete object[duplicatedKey]);
+  return srcValue;
 }

--- a/lib/schemas/artillery_test_script.json
+++ b/lib/schemas/artillery_test_script.json
@@ -9,7 +9,7 @@
         "environments": {
           "type": "object"
         },
-        "lowcaseHeaderKeys" {
+        "lowcaseHeaderKeys": {
           "type": "boolean"
         },
         "target": { "type": "string" },

--- a/lib/schemas/artillery_test_script.json
+++ b/lib/schemas/artillery_test_script.json
@@ -10,7 +10,7 @@
           "type": "object"
         },
         "lowcaseHeaderKeys" {
-          "type"; "boolean"
+          "type": "boolean"
         },
         "target": { "type": "string" },
         "phases": {

--- a/lib/schemas/artillery_test_script.json
+++ b/lib/schemas/artillery_test_script.json
@@ -9,7 +9,7 @@
         "environments": {
           "type": "object"
         },
-        "lowcaseHeaderKeys": {
+        "caseSensitiveHeaderKeys": {
           "type": "boolean"
         },
         "target": { "type": "string" },

--- a/lib/schemas/artillery_test_script.json
+++ b/lib/schemas/artillery_test_script.json
@@ -9,6 +9,9 @@
         "environments": {
           "type": "object"
         },
+        "lowcaseHeaderKeys" {
+          "type"; "boolean"
+        },
         "target": { "type": "string" },
         "phases": {
           "type": "array"

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -95,3 +95,15 @@ test('rendering variables', function(t) {
 
   t.end();
 });
+
+test('remove duplicated keys', function(t) {
+  t.deepEqual(L.mergeWith({}, {'X-Header': 123}, {'x-header': 123}, util.removeDuplicatedKeys), {'x-header': 123},
+    'Header should be overrided by lowercase');
+  t.deepEqual(L.mergeWith({}, {'x-header': 123}, {'X-Header': 123}, util.removeDuplicatedKeys), {'X-Header': 123},
+    'Header should be overrided by case-sensitive');
+  t.deepEqual(L.mergeWith({}, {'x-header': 123}, {'x-header': 234}, util.removeDuplicatedKeys), {'x-header': 234},
+    'Header should be overrided when got same keys');
+  t.deepEqual(L.mergeWith({}, {'x-Simple': 111, 'x-header': 123}, {'x-header': 234}, util.removeDuplicatedKeys), {'x-Simple': 111, 'x-header': 234},
+    'Header should remain existing keys');
+  t.end();
+});


### PR DESCRIPTION
From https://github.com/shoreditch-ops/artillery/issues/191, It would be nice if `artillery` can support case-sensitive header by adding following option in `config` ( default is off ) 
>    caseSensitiveHeaderKeys: true