### PR TITLE
Establish a single agent for all the scenarios

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -23,12 +23,31 @@ module.exports = HttpEngine;
 
 function HttpEngine(script) {
   this.config = script.config;
+  this.agent = (function(){
+    let config = script.config;
 
-  if (script.config.http && script.config.http.pool) {
-    this.pool = {
-      maxSockets: Number(script.config.http.pool)
+     // We'll ignore all the agent settings for HTTP2
+    if (config.http2) { return undefined; }
+
+    let tls = config.tls || {};
+    let pool = config.http ? Number(config.http.pool) : Infinity;
+    let agentOpts = {
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: pool,
+      maxFreeSockets: 256
     };
-  }
+
+    if ((/^https/i).test(config.target)) {
+      if (tls.pfx) {
+        // FIXME: Path needs to be resolved relative to Artillery's cwd
+        agentOpts.pfx = fs.readFileSync(tls.pfx);
+      }
+      return new https.Agent(agentOpts);
+    } else {
+      return new http.Agent(agentOpts);
+    }
+  }());
 }
 
 HttpEngine.prototype.createScenario = function(scenarioSpec, ee) {
@@ -175,6 +194,15 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     });
     requestParams = _.extend(requestParams, tls);
 
+
+    if (config.http2) {
+      requestParams.http2 = true;
+    }
+
+    if (self.agent) {
+      requestParams.agent = self.agent;
+    }
+
     let functionNames = _.concat(opts.beforeRequest || [], params.beforeRequest || []);
 
     async.eachSeries(
@@ -246,17 +274,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         if (typeof requestParams.auth === 'object') {
           requestParams.auth.user = template(requestParams.auth.user, context);
           requestParams.auth.pass = template(requestParams.auth.pass, context);
-        }
-
-        if (config.http2) {
-          requestParams.http2 = true;
-        } else {
-          if (!self.pool) {
-            requestParams.agent = context._agent;
-          } else {
-
-            requestParams.pool = self.pool;
-          }
         }
 
         let url = maybePrependBase(template(requestParams.uri || requestParams.url, context), config);
@@ -440,29 +457,6 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
 
     initialContext._jar = request.jar();
 
-    if (!config.http2) {
-      if (!self.pool) {
-        let agentOpts = {
-          keepAlive: true,
-          keepAliveMsecs: 1000,
-          maxSockets: 1,
-          maxFreeSockets: 1
-        };
-
-        // FIXME: This won't work if we have a pool - needs to be set in agentOptions
-        // in request params
-        if ((/^https/i).test(config.target)) {
-          if (tls.pfx) {
-            // FIXME: Path needs to be resolved relative to Artillery's cwd
-            agentOpts.pfx = fs.readFileSync(tls.pfx);
-          }
-          initialContext._agent = new https.Agent(agentOpts);
-        } else {
-          initialContext._agent = new http.Agent(agentOpts);
-        }
-      }
-    }
-
     let steps = _.flatten([
       function zero(cb) {
         ee.emit('started');
@@ -474,11 +468,6 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
     async.waterfall(
       steps,
       function scenarioWaterfallCb(err, context) {
-        // If the connection was refused we might not have a context
-        if (context && context._agent) {
-          context._agent.destroy();
-        }
-
         if (err) {
           //ee.emit('error', err.message);
           return callback(err, context);


### PR DESCRIPTION
Previously, each new scenario established a new request agent, which resulted
into inefficient use of HTTP connections. The same issue could be replicated
with both the custom and default pool settings.

This fix establishes a single request agent during the engine creation, which is
shared between all HTTP/HTTPS scenarios.

I wrote a crude test to verify the improvement:

```yaml
config:
  target: 'http://localhost:8080'
  http:
    timeout: 100
    pool: 100
  phases:
    - duration: 60
      arrivalRate: 1000
scenarios:
  - flow:
    - get:
        url: "/"
```

Results **WITHOUT** the fix:

```
Complete report @ 2017-06-29T12:28:17.784Z
  Scenarios launched:  60000
  Scenarios completed: 44221
  Requests completed:  44221
  RPS sent: 654.16
  Request latency:
    min: 0.6
    max: 2472
    median: 13.1
    p95: 28.6
    p99: 466.6
  Scenario duration:
    min: 0.9
    max: 2473.4
    median: 14
    p95: 30.7
    p99: 467.7
  Scenario counts:
    0: 60000 (100%)
  Codes:
    200: 43293
    404: 456
    500: 472
  Errors:
    EADDRNOTAVAIL: 15779
```

Results **WITH** the fix in place:

```
Complete report @ 2017-06-29T12:30:00.571Z
  Scenarios launched:  60000
  Scenarios completed: 60000
  Requests completed:  60000
  RPS sent: 984.09
  Request latency:
    min: 0.1
    max: 57.3
    median: 10.5
    p95: 19.8
    p99: 27.4
  Scenario duration:
    min: 0.3
    max: 57.6
    median: 10.9
    p95: 20.4
    p99: 28.1
  Scenario counts:
    0: 60000 (100%)
  Codes:
    200: 58750
    404: 656
    500: 594
```

These tests were ran on a Mid-2015 Macbook Pro (2.2 GHz Intel Core i7, 16GB RAM) with OSX El Capitan as the operating system.

As you can see, the first result produces a considerable amount of errors, while the second results don't produce any errors.