### PR TITLE
Add ability to run requests in parallel

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 const request = require('request');
 
 const debug = require('debug')('http');
+const debugRequests = require('debug')('http:request');
 const debugResponse = require('debug')('http:response');
 const debugFullBody = require('debug')('http:full_body');
 const USER_AGENT = 'Artillery (https://artillery.io)';
@@ -101,6 +102,19 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         whileTrue: self.config.processor ?
           self.config.processor[requestSpec.whileTrue] : undefined
       });
+  }
+
+  if (requestSpec.parallel) {
+    let steps = _.map(requestSpec.parallel, function(rs) {
+        return self.step(rs, ee, opts);
+    });
+
+    return engineUtil.createParallel(
+        steps,
+        {
+          limitValue: requestSpec.limit
+        }
+      );
   }
 
   if (requestSpec.think) {
@@ -402,6 +416,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
 
         request(requestParams, maybeCallback)
           .on('request', function(req) {
+            debugRequests("request start: %s", req.path);
             ee.emit('request');
 
             const startedAt = process.hrtime();
@@ -410,6 +425,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               let code = res.statusCode;
               const endedAt = process.hrtime(startedAt);
               let delta = (endedAt[0] * 1e9) + endedAt[1];
+              debugRequests("request end: %s", req.path);
               ee.emit('response', delta, code, context._uid);
             });
           }).on('end', function() {

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -25,6 +25,7 @@ try {
 module.exports = {
   createThink: createThink,
   createLoopWithCount: createLoopWithCount,
+  createParallel: createParallel,
   isProbableEnough: isProbableEnough,
   template: template,
   captureOrMatch,
@@ -123,6 +124,33 @@ function createLoopWithCount(count, steps, opts) {
       });
   };
 }
+
+function createParallel(steps, opts) {
+
+  let limit = (opts && opts.limitValue) || 100;
+
+  return function aParallel(context, callback) {
+    let newContext = context;
+    let newCallback = callback;
+
+    // Remap the steps array to pass the context into each step.
+    let newSteps = L.map(steps, function(step) {
+      return function(callback){
+        step(newContext, callback);
+      };
+    });
+
+    // Run each of the steps in parallel.
+    A.parallelLimit(
+      newSteps,
+      limit,
+      function(err, finalContext) {
+        // We don't need to do anything with the array of contexts returned from each step at the moment.
+        return newCallback(err, newContext);
+      });
+  };
+}
+
 
 function isProbableEnough(obj) {
   if (typeof obj.probability === 'undefined') {

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ require('./test_capture');
 require('./test_arrivals');
 require('./test_reuse');
 require('./test_loop');
+require('./test_parallel');
 require('./test_probability');
 require('./test_if');
 require('./ws/test_options');

--- a/test/scripts/parallel.json
+++ b/test/scripts/parallel.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "target": "http://localhost:3003",
+    "phases": [
+      {"duration": 10, "arrivalRate": 1}
+    ],
+    "statsInterval": 1
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {
+          "parallel": [
+            {"get": {"url": "/"}},
+            {"get": {"url": "/"}},
+            {"get": {"url": "/"}},
+            {"get": {"url": "/"}}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_parallel.js
+++ b/test/test_parallel.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const test = require('tape');
+const runner = require('../lib/runner').runner;
+const L = require('lodash');
+
+test('parallel requests', (t) => {
+  const script = require('./scripts/parallel.json');
+
+  runner(script).then(function(ee) {
+    ee.on('done', (report) => {
+      let scenarios = report.scenariosCompleted;
+      let requests = report.requestsCompleted;
+      let stepCount = script.scenarios[0].flow[0].parallel.length;
+      let expected = scenarios * stepCount;
+      t.equal(requests, expected, 'Should have ' + stepCount + ' requests for each completed scenario.');
+      t.notEqual(scenarios, 0, 'Should have at least 1 scenario successfully run');
+      t.end();
+    });
+    ee.run();
+  });
+});


### PR DESCRIPTION
For some apps, it has to handle multiple requests from a single user at once (e.g. API requests which are fired at the same time). 

This adds in a nested step with a similar syntax to the `loop` configuration which allows requests to be grouped together and run in parallel. Once all requests have completed, the load test then continues.