### PR TITLE
Allow passing variable of array back for global regexp

### DIFF
--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -457,17 +457,27 @@ function extractRegExp(doc, expr, opts) {
   } else {
       rx = new RegExp(expr);
   }
+  let matches = [];
   let match = rx.exec(str);
   if (!match) {
     return '';
   }
-  if(group && match[group]) {
-    return match[group];
-  } else if (match[0]) {
-    return match[0];
-  } else {
-    return '';
+  while (match != null) {
+    if(group && match[group]) {
+      matches.push(match[group]);
+    } else if (match[0]) {
+      matches.push(match[0]);
+    } else {
+      matches.push('');
+    }
+    if (flags && flags.includes('g')) {
+      match = rx.exec(str);
+    } else {
+      match = null;
+      matches = matches[0];
+    }
   }
+  return matches
 }
 
 function extractHeader(headers, headerName) {


### PR DESCRIPTION
If you use a capture, like the following, you can have multiple matches for the one regexp.

```yaml
- regexp: name="names\[\]" value="(.)"
  flags: g
  group: 1
  as: "names"
```

This change allows `names` to be an array of multiple items if the `g` flag is given.